### PR TITLE
Tweaks on .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,13 @@
 root = true
 
 [*]
-indent_style = tab
-end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
-
-[{package.json,*.yml}]
-indent_style = space
+end_of_line = lf
 indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+// Markdown uses two trailing spaces to define line breaks
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I removed the package.json/YAML section. There's no need to define them, since the default rule (`[*]`) is the same.
